### PR TITLE
Switch Clang container to Ubuntu 22.04

### DIFF
--- a/build_containers.sh
+++ b/build_containers.sh
@@ -73,6 +73,6 @@ build_clang_container ()
 
 CLANG_VERSION="12"
 GCC_VERSION="10"
-UBUNTU_VERSION="21.04"
+UBUNTU_VERSION="22.04"
 build_clang_container ${CLANG_VERSION} ${GCC_VERSION} ${UBUNTU_VERSION}
 


### PR DESCRIPTION
The current Ubuntu 21.04 container fails to install `clang` for whatever reason.