### PR TITLE
start_container: support setting environment variables

### DIFF
--- a/make_linux.py
+++ b/make_linux.py
@@ -92,7 +92,7 @@ def build_kernel(arch, kconfig, src, out, compiler, make_args):
         print('Going to run the container in the interactive mode (without build log)')
         stdout_destination = None
 
-    start_container_cmd.extend(['--', 'make', 'O=~/out/'])
+    start_container_cmd.extend(['--', 'make', 'O=../out/'])
 
     if compiler.startswith('clang'):
         print('Compiling with clang requires \'CC=clang\'')

--- a/make_linux.py
+++ b/make_linux.py
@@ -92,7 +92,7 @@ def build_kernel(arch, kconfig, src, out, compiler, make_args):
         print('Going to run the container in the interactive mode (without build log)')
         stdout_destination = None
 
-    start_container_cmd.extend(['make', 'O=~/out/'])
+    start_container_cmd.extend(['--', 'make', 'O=~/out/'])
 
     if compiler.startswith('clang'):
         print('Compiling with clang requires \'CC=clang\'')

--- a/start_container.sh
+++ b/start_container.sh
@@ -70,7 +70,7 @@ while [[ $# -gt 0 ]]; do
 		shift
 		break
 		;;
-	-* | --*)
+	*)
 		echo "Unknown option $1"
 		print_help
 		exit 1

--- a/start_container.sh
+++ b/start_container.sh
@@ -2,9 +2,10 @@
 
 function print_help {
 	echo "usage: $0 compiler src_dir out_dir [-n] [-h] [-e] [-- cmd with args]"
-	echo "  -n    launch container in non-interactive mode"
 	echo "  -e    space-separated list of environment variables"
 	echo "  -h    print this help"
+	echo "  -n    launch container in non-interactive mode"
+	echo "  -v    enable debug output"
 	echo ""
 	echo "  If cmd is empty, we will start an interactive bash in the container."
 }
@@ -14,8 +15,7 @@ NEED_SUDO=$?
 
 set -eu
 
-if [ $NEED_SUDO -eq 1 ]
-then
+if [ $NEED_SUDO -eq 1 ]; then
 	echo "Hey, we gonna use sudo for running docker"
 	SUDO_CMD="sudo"
 else
@@ -23,8 +23,7 @@ else
 	SUDO_CMD=""
 fi
 
-if [ $# -lt 3 ]
-then
+if [ $# -lt 3 ]; then
 	print_help
 	exit 1
 fi
@@ -46,45 +45,46 @@ ENV=""
 INTERACTIVE="-it"
 
 while [[ $# -gt 0 ]]; do
-  case $1 in
-    -n|--non-interactive)
-      INTERACTIVE=""
-      CIDFILE="--cidfile $OUT/container.id"
-      echo "Run docker in NON-interactive mode"
-      shift
-      ;;
-    -e|--env)
-      for var in $2
-      do
-        ENV="$ENV -e $var"
-      done
-      shift 2
-      ;;
-    -h|--help)
-      print_help
-      exit 0
-      ;;
-    --)
-      shift
-      break
-      ;;
-    -*|--*)
-      echo "Unknown option $1"
-      print_help
-      exit 1
-      ;;
-  esac
+	case $1 in
+	-n | --non-interactive)
+		INTERACTIVE=""
+		CIDFILE="--cidfile $OUT/container.id"
+		echo "Run docker in NON-interactive mode"
+		shift
+		;;
+	-e | --env)
+		for var in $2; do
+			ENV="$ENV -e $var"
+		done
+		shift 2
+		;;
+	-v | --verbose)
+		set -x
+		shift
+		;;
+	-h | --help)
+		print_help
+		exit 0
+		;;
+	--)
+		shift
+		break
+		;;
+	-* | --*)
+		echo "Unknown option $1"
+		print_help
+		exit 1
+		;;
+	esac
 done
 
 echo "Container environment: $ENV"
 
-if [ ! -z $INTERACTIVE ]
-then
+if [ ! -z $INTERACTIVE ]; then
 	echo "Run docker in interactive mode"
 fi
 
-if [ $# -gt 0 ]
-then
+if [ $# -gt 0 ]; then
 	echo -e "Gonna run \"$@\"\n"
 else
 	echo -e "Gonna run interactive bash...\n"
@@ -92,6 +92,6 @@ fi
 
 # Z for setting SELinux label
 exec $SUDO_CMD docker run $ENV $INTERACTIVE $CIDFILE --rm \
-  -v $SRC:/home/$(id -nu)/src:Z \
-  -v $OUT:/home/$(id -nu)/out:Z \
-  kernel-build-container:$COMPILER "$@"
+	-v $SRC:/home/$(id -nu)/src:Z \
+	-v $OUT:/home/$(id -nu)/out:Z \
+	kernel-build-container:$COMPILER "$@"

--- a/start_container.sh
+++ b/start_container.sh
@@ -1,7 +1,18 @@
 #!/bin/bash
 
+function print_help {
+	echo "usage: $0 compiler src_dir out_dir [-n] [-h] [-e] [-- cmd with args]"
+	echo "  -n    launch container in non-interactive mode"
+	echo "  -e    space-separated list of environment variables"
+	echo "  -h    print this help"
+	echo ""
+	echo "  If cmd is empty, we will start an interactive bash in the container."
+}
+
 groups | grep docker
 NEED_SUDO=$?
+
+set -eu
 
 if [ $NEED_SUDO -eq 1 ]
 then
@@ -12,13 +23,9 @@ else
 	SUDO_CMD=""
 fi
 
-set -e
-
 if [ $# -lt 3 ]
 then
-	echo "usage: $0 compiler src_dir out_dir [-n] [cmd with args]"
-	echo "  use '-n' for non-interactive session"
-	echo "  if cmd is empty, we will start an interactive bash in the container"
+	print_help
 	exit 1
 fi
 
@@ -31,19 +38,48 @@ echo "Source code directory \"$SRC\" is mounted at \"~/src\""
 OUT="$3"
 echo "Build output directory \"$OUT\" is mounted at \"~/out\""
 
-shift
-shift
-shift
+shift 3
 
-if [ $# -gt 0 -a "$1" = "-n" ]
+# defaults
+CIDFILE=""
+ENV=""
+INTERACTIVE="-it"
+
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    -n|--non-interactive)
+      INTERACTIVE=""
+      CIDFILE="--cidfile $OUT/container.id"
+      echo "Run docker in NON-interactive mode"
+      shift
+      ;;
+    -e|--env)
+      for var in $2
+      do
+        ENV="$ENV -e $var"
+      done
+      shift 2
+      ;;
+    -h|--help)
+      print_help
+      exit 0
+      ;;
+    --)
+      shift
+      break
+      ;;
+    -*|--*)
+      echo "Unknown option $1"
+      print_help
+      exit 1
+      ;;
+  esac
+done
+
+echo "Container environment: $ENV"
+
+if [ ! -z $INTERACTIVE ]
 then
-	INTERACTIVE=""
-	CIDFILE="--cidfile $OUT/container.id"
-	echo "Run docker in NON-interactive mode"
-	shift
-else
-	INTERACTIVE="-it"
-	CIDFILE=""
 	echo "Run docker in interactive mode"
 fi
 
@@ -55,7 +91,7 @@ else
 fi
 
 # Z for setting SELinux label
-exec $SUDO_CMD docker run $INTERACTIVE $CIDFILE --rm \
+exec $SUDO_CMD docker run $ENV $INTERACTIVE $CIDFILE --rm \
   -v $SRC:/home/$(id -nu)/src:Z \
   -v $OUT:/home/$(id -nu)/out:Z \
   kernel-build-container:$COMPILER "$@"

--- a/start_container.sh
+++ b/start_container.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
 function print_help {
-	echo "usage: $0 compiler src_dir out_dir [-n] [-h] [-e] [-- cmd with args]"
-	echo "  -e    space-separated list of environment variables"
+	echo "usage: $0 compiler src_dir out_dir [-e VAR] [-h] [-n] [-v] [-- cmd with args]"
+	echo "  -e    add environment variable in the container (may be used multiple times)"
 	echo "  -h    print this help"
 	echo "  -n    launch container in non-interactive mode"
 	echo "  -v    enable debug output"
@@ -53,9 +53,8 @@ while [[ $# -gt 0 ]]; do
 		shift
 		;;
 	-e | --env)
-		for var in $2; do
-			ENV="$ENV -e $var"
-		done
+		# `set -eu` will prevent out-of-bounds access
+		ENV="$ENV -e $2"
 		shift 2
 		;;
 	-v | --verbose)
@@ -78,7 +77,9 @@ while [[ $# -gt 0 ]]; do
 	esac
 done
 
-echo "Container environment: $ENV"
+if [ ! -z "$ENV" ]; then
+	echo "Container environment arguments: $ENV"
+fi
 
 if [ ! -z $INTERACTIVE ]; then
 	echo "Run docker in interactive mode"

--- a/start_container.sh
+++ b/start_container.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
 
 function print_help {
-	echo "usage: $0 compiler src_dir out_dir [-e VAR] [-h] [-n] [-v] [-- cmd with args]"
+	echo "usage: $0 compiler src_dir out_dir [-n] [-e VAR] [-h] [-v] [-- cmd with args]"
+	echo "  -n    launch container in non-interactive mode"
 	echo "  -e    add environment variable in the container (may be used multiple times)"
 	echo "  -h    print this help"
-	echo "  -n    launch container in non-interactive mode"
 	echo "  -v    enable debug output"
 	echo ""
 	echo "  If cmd is empty, we will start an interactive bash in the container."
@@ -29,14 +29,8 @@ if [ $# -lt 3 ]; then
 fi
 
 COMPILER=$1
-echo "Starting \"kernel-build-container:$COMPILER\""
-
 SRC="$2"
-echo "Source code directory \"$SRC\" is mounted at \"~/src\""
-
 OUT="$3"
-echo "Build output directory \"$OUT\" is mounted at \"~/out\""
-
 shift 3
 
 # defaults
@@ -77,18 +71,23 @@ while [[ $# -gt 0 ]]; do
 	esac
 done
 
+echo "Starting \"kernel-build-container:$COMPILER\""
+
 if [ ! -z "$ENV" ]; then
 	echo "Container environment arguments: $ENV"
 fi
 
 if [ ! -z $INTERACTIVE ]; then
-	echo "Run docker in interactive mode"
+	echo "Gonna run docker in interactive mode"
 fi
 
+echo "Mount source code directory \"$SRC\" at \"/home/$(id -nu)/src\""
+echo "Mount build output directory \"$OUT\" at \"/home/$(id -nu)/out\""
+
 if [ $# -gt 0 ]; then
-	echo -e "Gonna run \"$@\"\n"
+	echo -e "Gonna run command \"$@\"\n"
 else
-	echo -e "Gonna run interactive bash...\n"
+	echo -e "Gonna run bash\n"
 fi
 
 # Z for setting SELinux label


### PR DESCRIPTION
Change the parsing of optional flag parameters after the three mandatory positional arguments to use a while loop. Makes it easier to add more arguments in the future. 

Everything after `--` will be passed to the docker command. Note: This change will break existing scripts that execute commands in the container.

As a first use-case: Add support for specifying environment variables for the container on the command line in a space-separated list. Note: It is not possible to set environment variables that contain spaces.

Why: I like to customize builds through environment variables and doing `sh -c "FOO=BAR make"` is ugly. :)

Examples:
```console
$ export VAR=something
$ ./start_container.sh gcc-7 $(pwd) /tmp -e "FOO=BAR FOOBAR= VAR=$VAR" -- /usr/bin/env
Hey, we gonna use sudo for running docker
Starting "kernel-build-container:gcc-7"
Source code directory "/mnt/example/kernel-build-containers" is mounted at "~/src"
Build output directory "/tmp" is mounted at "~/out"
Container environment:  -e FOO=BAR -e FOOBAR= -e VAR=something
Run docker in interactive mode
Gonna run "/usr/bin/env"

PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
HOSTNAME=e769fbdf9d72
FOO=BAR
FOOBAR=
VAR=something
```

Note: `./start_container.sh gcc-7 $(pwd) /tmp -e "FOO=BAR" -e "FOOBAR=" -e "VAR=$VAR" -- /usr/bin/env` also works...

As further use case for the while-loop parsing: Add `--help` and `--verbose` flags.