### PR TITLE
Add cpio binary and help with silent and parallel builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ ARG CLANG_VERSION
 RUN set -x && echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections && \
     apt-get update && \
     apt-get install -y -q apt-utils dialog && \
-    apt-get install -y -q sudo aptitude flex bison libncurses5-dev make git exuberant-ctags sparse bc libssl-dev libelf-dev bsdmainutils && \
+    apt-get install -y -q sudo aptitude flex bison cpio libncurses5-dev make git exuberant-ctags sparse bc libssl-dev libelf-dev bsdmainutils && \
     if [ "$GCC_VERSION" ]; then \
       apt-get install -y -q gcc-${GCC_VERSION} g++-${GCC_VERSION} gcc-${GCC_VERSION}-plugin-dev gcc g++ \
         gcc-${GCC_VERSION}-aarch64-linux-gnu g++-${GCC_VERSION}-aarch64-linux-gnu gcc-aarch64-linux-gnu g++-aarch64-linux-gnu \

--- a/make_linux.py
+++ b/make_linux.py
@@ -101,7 +101,8 @@ def build_kernel(arch, kconfig, src, out, compiler, make_args):
         print('Going to run the container in the interactive mode (without build log)')
         stdout_destination = None
 
-    start_container_cmd.extend(['--', 'make', 'O=../out/'])
+    ocpus = os.sysconf('SC_NPROCESSORS_ONLN')
+    start_container_cmd.extend(['--', 'make',  '-s', '-j',  str(ocpus), 'O=../out/'])
 
     if compiler.startswith('clang'):
         print('Compiling with clang requires \'CC=clang\'')


### PR DESCRIPTION
Sometimes kernel build fails due to non availability of cpio archive in the container.
the kernel/gen_kheaders.sh file needs cpio archive to build kernel/kheaders_data.tar.xz

Similarly silent and parallel builds will help to build faster and show only relevant warnings or error messages.