### PR TITLE
add xz-utils package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ ARG CLANG_VERSION
 RUN set -x && echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections && \
     apt-get update && \
     apt-get install -y -q apt-utils dialog && \
-    apt-get install -y -q sudo aptitude flex bison cpio libncurses5-dev make git exuberant-ctags sparse bc libssl-dev libelf-dev bsdmainutils dwarves && \
+    apt-get install -y -q sudo aptitude flex bison cpio libncurses5-dev make git exuberant-ctags sparse bc libssl-dev libelf-dev bsdmainutils dwarves xz-utils && \
     if [ "$GCC_VERSION" ]; then \
       apt-get install -y -q gcc-${GCC_VERSION} g++-${GCC_VERSION} gcc-${GCC_VERSION}-plugin-dev \
         gcc-${GCC_VERSION}-aarch64-linux-gnu g++-${GCC_VERSION}-aarch64-linux-gnu \


### PR DESCRIPTION
hello, @a13xp0p0v !
i have litlle PR
first i got this error
```
      CALL    /home/vyashnikov/src/scripts/checksyscalls.sh      CHK     include/generated/compile.h
      UPD     include/generated/compile.h      CC      init/version.o
      AR      init/built-in.a      CHK     kernel/kheaders_data.tar.xz
      GEN     kernel/kheaders_data.tar.xz    /bin/sh: 1: xz: not found
    tar: kernel/kheaders_data.tar.xz: Cannot write: Broken pipe    tar: Child returned status 127
    tar: Error is not recoverable: exiting now    make[2]: *** [/home/vyashnikov/src/kernel/Makefile:150: kernel/kheaders_data.tar.xz] Error 2
    ...
 ```
 i also checked this util in dockerfile and container and didnt found `xz`
 