### PR TITLE
Support Building selftests

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ RUN set -ex; \
     echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections; \
     apt-get update; \
     apt-get install -y -q apt-utils dialog; \
-    apt-get install -y -q sudo aptitude flex bison cpio libncurses5-dev make git exuberant-ctags sparse bc libssl-dev libelf-dev bsdmainutils dwarves xz-utils zstd gawk; \
+    apt-get install -y -q sudo aptitude flex bison cpio libncurses5-dev make git exuberant-ctags sparse bc libssl-dev libelf-dev bsdmainutils dwarves xz-utils zstd gawk rsync; \
     apt-get install -y -q python3 python3-venv; \
     apt-get install -y -q python-is-python3 || apt-get install -y -q python; \
     if [ "$GCC_VERSION" ]; then \

--- a/build_linux.py
+++ b/build_linux.py
@@ -120,9 +120,6 @@ def build_kernel(arch, kconfig, src, out, compiler, make_args):
 
     start_container_cmd.extend(make_args)
 
-    if noninteractive:
-        start_container_cmd.extend(['2>&1'])
-
     print(f'Run the container: {" ".join(start_container_cmd)}')
     interrupt = False
     with subprocess.Popen(start_container_cmd, stdout=stdout_destination, stderr=subprocess.STDOUT,


### PR DESCRIPTION
From 3d355ae78bfe8e3c777bac800ac3bc9165dfb68c Mon Sep 17 00:00:00 2001
From: Evangelos Petrongonas <vpetrog@ieee.org>
Date: Mon, 14 Jul 2025 00:27:21 +0200
Subject: [PATCH 0/2] ***Support building Selftests***

When working with linux, kernel headers are often required when building out of tree modules or various userspace components, or the kernel selftests.

This patchset adds support building linux selftests by extending the docker containers to include the rsync utilinig, which is neccessary for installing the headers and removing the manual shell redirection of `stderr` to `stdout`, which was polluting  the `make` arguments. It is handled instead via the, already existing, `Popen` `stderr=..` argument.

Evangelos Petrongonas (2):
  Dockerfile: Add rsync to the container
  build_linux: Remove manual shell redirection

```
 Dockerfile     | 2 +-
 build_linux.py | 3 ---
 2 files changed, 1 insertion(+), 4 deletions(-)
```
-- 
2.50.1

