### PR TITLE
Readme: convert gcc and clang compatibility to Markdown tables

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,46 +21,36 @@ License: GPL-3.0.
 
 ## Supported features
 
-__Supported build targets:__
+__Supported kernel build targets:__
  - `x86_64`
  - `i386`
  - `arm64` (toolchain name `aarch64`)
  - `arm`
  - `riscv` (toolchain name `riscv64`)
 
-__Supported gcc versions:__
-| gcc     | i386 | x86_64 | arm | arm64 | riscv |
-| ------- | ---- | ------ | --- | ----- | ----- |
-| gcc-4.9 | ✓    | ✓      | *   | *     |       |
-| gcc-5   | ✓    | ✓      | ✓   | ✓     |       |
-| gcc-6   | ✓    | ✓      | ✓   | ✓     |       |
-| gcc-7   | ✓    | ✓      | ✓   | ✓     | ✓     |
-| gcc-8   | ✓    | ✓      | ✓   | ✓     | ✓     |
-| gcc-9   | ✓    | ✓      | ✓   | ✓     | ✓     |
-| gcc-10  | ✓    | ✓      | ✓   | ✓     | ✓     |
-| gcc-11  | ✓    | ✓      | ✓   | ✓     | ✓     |
-| gcc-12  | ✓    | ✓      | ✓   | ✓     | ✓     |
-| gcc-13  | ✓    | ✓      | ✓   | ✓     | ✓     |
-| gcc-14  | ✓    | ✓      | ✓   | ✓     | ✓     |
+__Supported GCC versions:__
 
-*\*Doesn't support `gcc-plugins`*
+|             | x86_64 | i386 | arm64 | arm | riscv |
+| ----------- | ------ | ---- | ----- | --- | ----- |
+| __gcc-4.9__ | ✓      | ✓    | *     | *   |       |
+| __gcc-5__   | ✓      | ✓    | ✓     | ✓   |       |
+| __gcc-6__   | ✓      | ✓    | ✓     | ✓   |       |
+| __gcc-7__   | ✓      | ✓    | ✓     | ✓   | ✓     |
+| __gcc-8__   | ✓      | ✓    | ✓     | ✓   | ✓     |
+| __gcc-9__   | ✓      | ✓    | ✓     | ✓   | ✓     |
+| __gcc-10__  | ✓      | ✓    | ✓     | ✓   | ✓     |
+| __gcc-11__  | ✓      | ✓    | ✓     | ✓   | ✓     |
+| __gcc-12__  | ✓      | ✓    | ✓     | ✓   | ✓     |
+| __gcc-13__  | ✓      | ✓    | ✓     | ✓   | ✓     |
+| __gcc-14__  | ✓      | ✓    | ✓     | ✓   | ✓     |
 
-__Supported clang versions:__
-| clang    | i386 | x86_64 | arm | arm64 | riscv |
-| -------- | ---- | ------ | --- | ----- | ----- |
-| clang-5  | ✓    | ✓      | ✓   | ✓     | ✓     |
-| clang-6  | ✓    | ✓      | ✓   | ✓     | ✓     |
-| clang-7  | ✓    | ✓      | ✓   | ✓     | ✓     |
-| clang-8  | ✓    | ✓      | ✓   | ✓     | ✓     |
-| clang-9  | ✓    | ✓      | ✓   | ✓     | ✓     |
-| clang-10 | ✓    | ✓      | ✓   | ✓     | ✓     |
-| clang-11 | ✓    | ✓      | ✓   | ✓     | ✓     |
-| clang-12 | ✓    | ✓      | ✓   | ✓     | ✓     |
-| clang-13 | ✓    | ✓      | ✓   | ✓     | ✓     |
-| clang-14 | ✓    | ✓      | ✓   | ✓     | ✓     |
-| clang-15 | ✓    | ✓      | ✓   | ✓     | ✓     |
-| clang-16 | ✓    | ✓      | ✓   | ✓     | ✓     |
-| clang-17 | ✓    | ✓      | ✓   | ✓     | ✓     |
+*\* marks a GCC version that doesn't support `gcc-plugins`*
+
+__Supported Clang versions:__
+
+`kernel-build-containers` provides all versions of Clang from `clang-5` to `clang-17`.
+
+The Clang compiler binary and corresponding LLVM utilities typically contain all supported backends for cross compiling.
 
 ## How to build container images
 


### PR DESCRIPTION
Small PR to convert the compiler compatibility matrices from bullet-point lists to Markdown tables, which I think look a little nicer.

As a side question (if you don't mind me asking here): I've been maintaining a private fork of this repo that adds support for GCC versions all the way back to gcc-3.3, which nearly doubles the number of available images. Would you be interested in potentially accepting a PR for that if I were to make one? Thanks for this very useful project either way!